### PR TITLE
Allow to specify quarto version

### DIFF
--- a/install-quarto/README.md
+++ b/install-quarto/README.md
@@ -12,10 +12,11 @@ This action will:
 Inputs available
 
 * `version` - _optional_. If provided, the specific quarto version will be installed. Ex: `version: 0.3.71`
+  **Only available on `main` branch**
 
   ```yaml
     steps:
-      - uses: quarto-dev/quarto-actions/install-quarto@master
+      - uses: quarto-dev/quarto-actions/install-quarto@main
         with:
           version: 0.3.71
   ```

--- a/install-quarto/README.md
+++ b/install-quarto/README.md
@@ -1,8 +1,24 @@
 # install-quarto
 
-Install last Quarto release (https://github.com/quarto-dev/quarto-cli/releases) using GitHub Actions. This action can be used to install Quarto on all runner OS and `quarto` will be available from PATH.
+Install a Quarto release (https://github.com/quarto-dev/quarto-cli/releases) using GitHub Actions. This action can be used to install Quarto on all runner OS and `quarto` will be available from PATH
 
 ## Usage
+
+This action will:
+
+* Download the Github Release of Quarto on Mac and Linux and install it
+* On Windows, it will for now use Scoop to install Quarto, as we have still an issue with Quarto MSI on Github Action (https://github.com/quarto-dev/quarto-cli/issues/108)
+
+Inputs available
+
+* `version` - _optional_. If provided, the specific quarto version will be installed. Ex: `version: 0.3.71`
+
+  ```yaml
+    steps:
+      - uses: quarto-dev/quarto-actions/install-quarto@master
+        with:
+          version: 0.3.71
+  ```
 
 Example on different OS:
 
@@ -33,7 +49,3 @@ jobs:
           quarto --version
 ```
 
-This action will 
-
-* Download the Github Release of quarto on Mac and Linux and install it
-* On Windows, it will for now use Scoop to install Quarto msi, until Quarto MSI file can be installed on Github Action (https://github.com/quarto-dev/quarto-cli/issues/108)

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -1,6 +1,10 @@
 name: 'Install Quarto'
 author: 'Christophe Dervieux'
 description: 'This actions will install Quarto binary from https://github.com/quarto-dev/quarto-cli/'
+inputs:
+  version:
+    description: 'The version of Quarto CLI to install, as a release tag (https://github.com/quarto-dev/quarto-cli/releases). Ex: 0.3.73'
+    required: false
 runs:
   using: 'composite'
   steps: 
@@ -22,6 +26,11 @@ runs:
               exit 1
               ;;
         esac
+        # set version
+        if [ ! -z "${{inputs.version}}" ]
+        then
+          echo "QUARTO_VERSION=v${{inputs.version}}" >> $GITHUB_ENV
+        fi
       shell: bash
     - name: 'Download Quarto release'
       id: download-quarto 
@@ -31,7 +40,7 @@ runs:
         # download the latest release
         if [ ${{ runner.os }} != "Windows" ]; then
          # On Windows scoop will be used so no need to download the release
-         gh release download --repo quarto-dev/quarto-cli --pattern ${{ format('*.{0}', env.BUNDLE_EXT) }}
+         gh release download ${{env.QUARTO_VERSION}} --repo quarto-dev/quarto-cli --pattern ${{ format('*.{0}', env.BUNDLE_EXT) }}
          echo "::set-output name=installer::$(ls quarto*.$BUNDLE_EXT)"
         fi
       shell: bash
@@ -48,7 +57,12 @@ runs:
               ;;
            "Windows")
               # can't install msi for now so use scoop
-              powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1
+              if [ -z "${{ env.QUARTO_VERSION }}" ]
+              then
+                powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1
+              else
+                powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1 -version ${{ env.QUARTO_VERSION }}
+              fi
               ;;
             *)
               echo "$RUNNER_OS not supported"

--- a/install-quarto/install-quarto-windows.ps1
+++ b/install-quarto/install-quarto-windows.ps1
@@ -14,8 +14,8 @@
     ttps:/go.microsoft.com/fwlink/?LinkID=135170
 #>
 
-# Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-# Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 
 param ($version)
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git

--- a/install-quarto/install-quarto-windows.ps1
+++ b/install-quarto/install-quarto-windows.ps1
@@ -14,7 +14,13 @@
     ttps:/go.microsoft.com/fwlink/?LinkID=135170
 #>
 
-Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
-Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+# Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+# Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+
+param ($version)
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
-scoop install quarto
+if ([string]::IsNullOrEmpty($version)) {
+    scoop install quarto
+}else{
+    Invoke-Expression -Command "scoop install quarto@$version"
+}


### PR DESCRIPTION
This PR add support for specifying the quarto version. 

````yaml
    steps:
      - uses: quarto-dev/quarto-actions/install-quarto@main
        with:
          version: 0.3.71
```

closes #6 