### PR TITLE
Remove `gh` dependency for Linux and MacOS when a version is specified 

### DIFF
--- a/install-quarto/README.md
+++ b/install-quarto/README.md
@@ -7,7 +7,8 @@ Install a Quarto release (https://github.com/quarto-dev/quarto-cli/releases) usi
 This action will:
 
 * Download the Github Release of Quarto on Mac and Linux and install it
-* On Windows, it will for now use Scoop to install Quarto, as we have still an issue with Quarto MSI on Github Action (https://github.com/quarto-dev/quarto-cli/issues/108)
+* On Windows, it will for now use **Scoop** (https://github.com/ScoopInstaller/Scoop) to install Quarto, as we have still an issue with Quarto MSI on Github Action (https://github.com/quarto-dev/quarto-cli/issues/108). (**Scoop** will be installed on the runner by the action)
+* On Linux and MacOS, it will use **gh** CLI to download the last available bundle (no `version` specified as input). If you don't have **gh** on your Github Action runner, you can specify a fix `version` to directly download from a URL using `wget`.
 
 Inputs available
 

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -13,36 +13,36 @@ runs:
         # Select correct bundle for OS type
         case $RUNNER_OS in 
           "Linux")
-              echo "BUNDLE_EXT=deb" >> $GITHUB_ENV
+              echo "BUNDLE_EXT=linux-amd64.deb" >> $GITHUB_ENV
               ;;
            "macOS")
-              echo "BUNDLE_EXT=pkg" >> $GITHUB_ENV
+              echo "BUNDLE_EXT=macos.pkg" >> $GITHUB_ENV
               ;;
            "Windows")
-              echo "BUNDLE_EXT=msi" >> $GITHUB_ENV
+              echo "BUNDLE_EXT=win.msi" >> $GITHUB_ENV
               ;;
             *)
               echo "$RUNNER_OS not supported"
               exit 1
               ;;
         esac
-        # set version
-        if [ ! -z "${{inputs.version}}" ]
-        then
-          echo "QUARTO_VERSION=v${{inputs.version}}" >> $GITHUB_ENV
-        fi
       shell: bash
     - name: 'Download Quarto release'
       id: download-quarto 
       env: 
         GITHUB_TOKEN: ${{ github.token }}
       run: |
-        # download the latest release
         if [ ${{ runner.os }} != "Windows" ]; then
-         # On Windows scoop will be used so no need to download the release
-         gh release download ${{env.QUARTO_VERSION}} --repo quarto-dev/quarto-cli --pattern ${{ format('*.{0}', env.BUNDLE_EXT) }}
-         echo "::set-output name=installer::$(ls quarto*.$BUNDLE_EXT)"
+          # On Windows scoop will be used so no need to download the release
+          if [ -z "${{inputs.version}}" ]; then
+            # download the latest release
+            gh release download --repo quarto-dev/quarto-cli --pattern ${{ format('*.{0}', env.BUNDLE_EXT) }}
+          else
+            # download a specific release
+            wget https://github.com/quarto-dev/quarto-cli/releases/download/v${{inputs.version}}/quarto-${{inputs.version}}-${{env.BUNDLE_EXT}}
+          fi
         fi
+        echo "::set-output name=installer::$(ls quarto*${{ env.BUNDLE_EXT }})"
       shell: bash
     - name: 'Install Quarto'
       run: |

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -61,7 +61,7 @@ runs:
               then
                 powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1
               else
-                powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1 -version ${{ inputs.version }}
+                powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1 ${{ inputs.version }}
               fi
               ;;
             *)

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -57,11 +57,11 @@ runs:
               ;;
            "Windows")
               # can't install msi for now so use scoop
-              if [ -z "${{ env.QUARTO_VERSION }}" ]
+              if [ -z "${{ inputs.version }}" ]
               then
                 powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1
               else
-                powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1 -version ${{ env.QUARTO_VERSION }}
+                powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1 -version ${{ inputs.version }}
               fi
               ;;
             *)

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -36,7 +36,7 @@ runs:
           # On Windows scoop will be used so no need to download the release
           if [ -z "${{inputs.version}}" ]; then
             # download the latest release
-            gh release download --repo quarto-dev/quarto-cli --pattern ${{ format('*.{0}', env.BUNDLE_EXT) }}
+            gh release download --repo quarto-dev/quarto-cli --pattern ${{ format('*{0}', env.BUNDLE_EXT) }}
           else
             # download a specific release
             wget https://github.com/quarto-dev/quarto-cli/releases/download/v${{inputs.version}}/quarto-${{inputs.version}}-${{env.BUNDLE_EXT}}

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -41,8 +41,8 @@ runs:
             # download a specific release
             wget https://github.com/quarto-dev/quarto-cli/releases/download/v${{inputs.version}}/quarto-${{inputs.version}}-${{env.BUNDLE_EXT}}
           fi
-        fi
         echo "::set-output name=installer::$(ls quarto*${{ env.BUNDLE_EXT }})"
+        fi
       shell: bash
     - name: 'Install Quarto'
       run: |

--- a/install-quarto/install-quarto-windows.ps1
+++ b/install-quarto/install-quarto-windows.ps1
@@ -17,7 +17,7 @@
 Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 
-param ($version)
+$version=$args[0]
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
 if ([string]::IsNullOrEmpty($version)) {
     scoop install quarto

--- a/install-quarto/install-quarto-windows.ps1
+++ b/install-quarto/install-quarto-windows.ps1
@@ -17,7 +17,7 @@
 Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 
-param ($version)
+param ($version='')
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
 if ([string]::IsNullOrEmpty($version)) {
     scoop install quarto

--- a/install-quarto/install-quarto-windows.ps1
+++ b/install-quarto/install-quarto-windows.ps1
@@ -17,7 +17,7 @@
 Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
 Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 
-param ($version='')
+param ($version)
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
 if ([string]::IsNullOrEmpty($version)) {
     scoop install quarto


### PR DESCRIPTION
This will close #5 by providing a mechanism to install Quarto on GHA runner without **gh** CLI available. 

Specifying a version will now directly download the correct version using `wget`

```yaml
  steps:
    - uses: quarto-dev/quarto-actions/install-quarto@main
      with:
        version: 0.3.71
```