### PR TITLE
Allow to install tinytex as part of install-quarto

### DIFF
--- a/install-quarto/README.md
+++ b/install-quarto/README.md
@@ -10,6 +10,8 @@ This action will:
 * On Windows, it will for now use **Scoop** (https://github.com/ScoopInstaller/Scoop) to install Quarto, as we have still an issue with Quarto MSI on Github Action (https://github.com/quarto-dev/quarto-cli/issues/108). (**Scoop** will be installed on the runner by the action)
 * On Linux and MacOS, it will use **gh** CLI to download the last available bundle (no `version` specified as input). If you don't have **gh** on your Github Action runner, you can specify a fix `version` to directly download from a URL using `wget`.
 
+We recommend using this action on Linux or MacOS where it works best, especially if TinyTeX is needed.
+
 ### Inputs available
 
 * `version` - _optional_. If provided, the specific quarto version will be installed. Ex: `version: 0.3.71`
@@ -21,7 +23,8 @@ This action will:
           version: 0.3.71
   ```
 
-* `tinytex` - _optional_. Set this to `tinytex: true` to let [Quarto installs TinyTeX](https://quarto.org/docs/output-formats/pdf-engine.html#installing-tex) using `quarto tools install tinytex`.  **Only available on `main` branch**
+* `tinytex` - _optional_. Set this to `tinytex: true` to let [Quarto installs TinyTeX](https://quarto.org/docs/output-formats/pdf-engine.html#installing-tex) using `quarto tools install tinytex`.  **Only available on `main` branch**  
+_Notice: Installing TinyTeX on Windows takes long time several minutes and will make your all job longer_
 
   ```yaml
     steps:

--- a/install-quarto/README.md
+++ b/install-quarto/README.md
@@ -13,7 +13,6 @@ This action will:
 Inputs available
 
 * `version` - _optional_. If provided, the specific quarto version will be installed. Ex: `version: 0.3.71`
-  **Only available on `main` branch**
 
   ```yaml
     steps:

--- a/install-quarto/README.md
+++ b/install-quarto/README.md
@@ -10,7 +10,7 @@ This action will:
 * On Windows, it will for now use **Scoop** (https://github.com/ScoopInstaller/Scoop) to install Quarto, as we have still an issue with Quarto MSI on Github Action (https://github.com/quarto-dev/quarto-cli/issues/108). (**Scoop** will be installed on the runner by the action)
 * On Linux and MacOS, it will use **gh** CLI to download the last available bundle (no `version` specified as input). If you don't have **gh** on your Github Action runner, you can specify a fix `version` to directly download from a URL using `wget`.
 
-Inputs available
+### Inputs available
 
 * `version` - _optional_. If provided, the specific quarto version will be installed. Ex: `version: 0.3.71`
 
@@ -21,7 +21,16 @@ Inputs available
           version: 0.3.71
   ```
 
-Example on different OS:
+* `tinytex` - _optional_. Set this to `tinytex: true` to let [Quarto installs TinyTeX](https://quarto.org/docs/output-formats/pdf-engine.html#installing-tex) using `quarto tools install tinytex`.  **Only available on `main` branch**
+
+  ```yaml
+    steps:
+      - uses: quarto-dev/quarto-actions/install-quarto@main
+        with:
+          tinytex: true
+  ```
+
+### Example on different OS
 
 ```yaml
 name: quarto-setup

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -80,5 +80,5 @@ runs:
       if: ${{ inputs.tinytex == 'true'}}
       run: |
         quarto tools install tinytex
-        echo "$HOME/.TinyTeX" >> $GITHUB_PATH
+        echo "$HOME/bin" >> $GITHUB_PATH
       shell: bash

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -5,6 +5,10 @@ inputs:
   version:
     description: 'The version of Quarto CLI to install, as a release tag (https://github.com/quarto-dev/quarto-cli/releases). Ex: 0.3.73'
     required: false
+  tinytex:
+    description: 'Should TinyTex be installed for PDF rendering using TeX Live ?'
+    required: false
+    default: 'false'
 runs:
   using: 'composite'
   steps: 
@@ -71,4 +75,10 @@ runs:
         esac
         [ ${{ runner.os }} != "Windows" ] && rm $installer
         echo "Quarto Installed !"
+      shell: bash
+    - name: Install TinyTeX
+      if: ${{ inputs.tinytex == 'true'}}
+      run: |
+        quarto tools install tinytex
+        echo "$HOME/.TinyTeX" >> $GITHUB_PATH
       shell: bash

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -89,6 +89,7 @@ runs:
               ;;
            "Windows")
               echo "$(dirname $(find $APPDATA/TinyTeX -name tlmgr.bat))" >> $GITHUB_PATH
+              ;;
             *)
               echo "$RUNNER_OS not supported"
               exit 1

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -80,17 +80,7 @@ runs:
       if: ${{ inputs.tinytex == 'true'}}
       run: |
         quarto tools install tinytex
-        case $RUNNER_OS in 
-          "Linux")
-              echo "$HOME/bin" >> $GITHUB_PATH
-              ;;
-           "macOS")
-              ;;
-           "Windows")
-              echo "%APPDATA%/TinyTeX/bin/win32" >> $GITHUB_PATH
-            *)
-              echo "$RUNNER_OS not supported"
-              exit 1
-              ;;
-        esac
+        install_dir=$(quarto tools info tinytex | jq -r '.directory')
+        bin_dir=$(dirname $(find $install_dir -name tlmgr))
+        echo $bin_dir >> $GITHUB_PATH
       shell: bash

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -80,5 +80,17 @@ runs:
       if: ${{ inputs.tinytex == 'true'}}
       run: |
         quarto tools install tinytex
-        echo "$HOME/bin" >> $GITHUB_PATH
+        case $RUNNER_OS in 
+          "Linux")
+              echo "$HOME/bin" >> $GITHUB_PATH
+              ;;
+           "macOS")
+              ;;
+           "Windows")
+              echo "%APPDATA%/TinyTeX/bin/win32" >> $GITHUB_PATH
+            *)
+              echo "$RUNNER_OS not supported"
+              exit 1
+              ;;
+        esac
       shell: bash

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -80,6 +80,19 @@ runs:
       if: ${{ inputs.tinytex == 'true'}}
       run: |
         quarto tools install tinytex --log-level warning
-        bin_dir=$(quarto tools info tinytex | jq -r '.["bin-directory"]')
-        echo $bin_dir >> $GITHUB_PATH
+        case $RUNNER_OS in 
+          "Linux")
+              echo "$HOME/bin" >> $GITHUB_PATH
+              ;;
+           "macOS")
+              echo "$(dirname $(find ~/Library/TinyTeX -name tlmgr))" >> $GITHUB_PATH
+              ;;
+           "Windows")
+              echo "$(dirname $(find $APPDATA/TinyTeX -name tlmgr.bat))" >> $GITHUB_PATH
+            *)
+              echo "$RUNNER_OS not supported"
+              exit 1
+              ;;
+        esac
+        echo "TinyTeX installed !"
       shell: bash

--- a/install-quarto/action.yml
+++ b/install-quarto/action.yml
@@ -79,8 +79,7 @@ runs:
     - name: Install TinyTeX
       if: ${{ inputs.tinytex == 'true'}}
       run: |
-        quarto tools install tinytex
-        install_dir=$(quarto tools info tinytex | jq -r '.directory')
-        bin_dir=$(dirname $(find $install_dir -name tlmgr))
+        quarto tools install tinytex --log-level warning
+        bin_dir=$(quarto tools info tinytex | jq -r '.["bin-directory"]')
         echo $bin_dir >> $GITHUB_PATH
       shell: bash

--- a/install-quarto/install-quarto-windows.ps1
+++ b/install-quarto/install-quarto-windows.ps1
@@ -14,7 +14,8 @@
     ttps:/go.microsoft.com/fwlink/?LinkID=135170
 #>
 
-Invoke-Expression (New-Object System.Net.WebClient).DownloadString('https://get.scoop.sh')
+Invoke-WebRequest -useb get.scoop.sh -outfile 'install.ps1'
+.\install.ps1 -RunAsAdmin
 Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
 
 $version=$args[0]


### PR DESCRIPTION
This PR allows to install TinyTeX as part of `install-quarto` step 

Syntax will be this one

````yaml
      - uses: quarto-dev/quarto-actions/install-quarto@v1
        with:
          tinytex: true
````

paths to binaries are computed based on logic in `tinytex.ts` in quarto-cli and added manually to PATH by the action as `quarto tools install tinytex` won't do it correctly in GHA runners

On Windows, the action is taking several minutes (~10-14min) because of how long it takes for unzipping TinyTeX bundles using Deno `unzip` which uses `Expand-Archive` on Windows which is quite long. There is room for improvement. 
(I am wondering about using `scoop install tinytex` or chocolatey that are faster).
