### PR TITLE
`quarto-book-netlify`: Not enable commit comment by default

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -10,7 +10,7 @@ You'll find here some generic workflows for Quarto projects.
 
 - [`quarto-book-netlify`](./quarto-book-netlify.yaml): Render an HTML Quarto Book and deploy to [Netlify](https://www.netlify.com). You must also config 2 github secrets:
   - `NETLIFY_AUTH_TOKEN`: [Personal access tokens](https://app.netlify.com/user/applications#personal-access-tokens) > New access token
-  - `NETLIFY_SITE_ID`: team page > your site > Settings > Site details > Site information > API ID
+  - `NETLIFY_SITE_ID`: team page > your site > Settings > Site details > Site information > Site ID
   - More details see [this Netlify action](https://github.com/nwtgck/actions-netlify).
 
 ### How to use ?

--- a/examples/quarto-book-netlify.yaml
+++ b/examples/quarto-book-netlify.yaml
@@ -30,7 +30,7 @@ jobs:
         run: |
           quarto render
 
-      - name: Deploy to Netlify
+      - name: Deploy to Netlify 🚀
         id: netlify-deploy
         uses: nwtgck/actions-netlify@v1
         with:
@@ -40,9 +40,11 @@ jobs:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           deploy-message:
             'Deploy from GHA: ${{ github.event.pull_request.title || github.event.head_commit.message }} (${{ github.sha }})'
-          enable-pull-request-comment: true #  Comment on pull request
-          enable-commit-comment: true # Comment on GitHub commit
-          enable-commit-status: true # GitHub commit status 
+          # If `true`, GHA will comment with a link to deploy preview as triggered by:
+          enable-pull-request-comment: true # Pull Request.
+          enable-commit-comment: false  # Push directly to `production-branch` (i.e., main).
+          # If `true`, GHA will display a "check" (✔️) for a successful "Netlify deployment".
+          enable-commit-status: true 
         env:
           NETLIFY_AUTH_TOKEN: ${{ secrets.NETLIFY_AUTH_TOKEN }}
           NETLIFY_SITE_ID: ${{ secrets.NETLIFY_SITE_ID }}


### PR DESCRIPTION
Hi, I would like to update the followings.

### Deploy Book to Netlify YAML

1. I write more descriptions in the comment

2. I've changed the value of `enable-commit-comment` from `true` to `false` because it seems **too noisy** from the GHA notifications that user will receive every time as content get pushed directly to main branch. 

```yaml
enable-pull-request-comment: true
enable-commit-comment: false
enable-commit-status: true
```

In summary, the above default values should get.

- PR (that might be important) will get deploy preview link by default.
- Push directly to main branch will be silent with no notification.
- Check in the background will be done either by PR or push to main.

This changes also inspired from my experience as I use PR for important changes and other non-significant changes I push right away to the book (that should give no notification).

(See [My Testing Repo](https://github.com/Lightbridge-KS/quarto-book-test) for this updated version)

### README

- Update instruction to get `NETLIFY_SITE_ID` with the current text displayed in Netlify site.

Thankyou