### PR TITLE
ci: update actions/checkout from v2 to v3 in example

### DIFF
--- a/examples/quarto-publish-example.yml
+++ b/examples/quarto-publish-example.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v2 
+        uses: actions/checkout@v3
         
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
This PR updates the GitHub Action "checkout" from v2 to v3.
See <https://github.com/actions/checkout>.