### PR TITLE
Add installing Julia deps to documentation

### DIFF
--- a/examples/example-03-dependencies.md
+++ b/examples/example-03-dependencies.md
@@ -50,4 +50,7 @@ Add the following entry to your GitHub Actions workflow:
 
 ## Installing Julia
 
-TBF.
+```yaml
+- uses: julia-actions/setup-julia@v1
+- run: julia --project -e 'using Pkg; Pkg.instantiate()'
+```


### PR DESCRIPTION
I'm a bit confused by the YAML syntax, but this is what I'm (approximately) using [here](https://github.com/cadojo/aperiodic/blob/main/.github/workflows/publish.yml) and it works fine!