### PR TITLE
Resolve set-output deprecation

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -49,7 +49,7 @@ runs:
             # download a specific release
             wget https://github.com/quarto-dev/quarto-cli/releases/download/v${{inputs.version}}/quarto-${{inputs.version}}-${{env.BUNDLE_EXT}}
           fi
-        echo "::set-output name=installer::$(ls quarto*${{ env.BUNDLE_EXT }})"
+        echo "installer=$(ls quarto*${{ env.BUNDLE_EXT }})" >> $GITHUB_OUTPUT
         fi
       shell: bash
     - name: 'Install Quarto'


### PR DESCRIPTION
See https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/

@cderv We have until May 2023 before this is removed, so no hurry, but since you added that line of code, I wanted to run this PR by you just to make sure you're ok with it.