### PR TITLE
render/action.yml: add missing space to inline bash script

### DIFF
--- a/render/action.yml
+++ b/render/action.yml
@@ -21,7 +21,7 @@ runs:
         fi
         if [ -f "_book" ]; then
           echo "QUARTO_OUTPUT=_book" >> $GITHUB_ENV
-        elif [ -f "_site"]; then
+        elif [ -f "_site" ]; then
           echo "QUARTO_OUTPUT=_site" >> $GITHUB_ENV
         fi
       shell: bash


### PR DESCRIPTION
I had been seeing this in my github action runs:

    /home/runner/work/_temp/caead89a-f3b1-44e5-bdd3-cd2ff43d26ef.sh: line 8: [: missing `]'

and I think adding the space there should resolve it.
