### PR TITLE
Clarify that actions can be used on projects OR single .qmd files

### DIFF
--- a/publish/README.md
+++ b/publish/README.md
@@ -59,5 +59,5 @@ Give this token a memorable name, and note the resulting string (or keep this wi
 
 The `with` parameter can also be set to configure the following
 
-* `path`: Subdirectory containing the quarto project to be published. Default to working directory (`.`)
+* `path`: Subdirectory containing the quarto project to be published or path to individual .qmd file. Default to working directory (`.`)
 * `render`: Set to `render: "false"` to skip rendering of project before publishing. By default, this `publish` action will render to all formats defined.

--- a/render/README.md
+++ b/render/README.md
@@ -5,5 +5,5 @@
   uses: quarto-dev/quarto-actions/render@v2
   with:
     to: html # If set, it will be equivalent to `quarto render --to html`
-    path: source-folder # By default, the current working dir is used i.e `quarto render .`
+    path: source-folder # By default, the current working dir is used i.e `quarto render .` Can also be a path to a single .qmd file.
 ```

--- a/render/README.md
+++ b/render/README.md
@@ -5,5 +5,7 @@
   uses: quarto-dev/quarto-actions/render@v2
   with:
     to: html # If set, it will be equivalent to `quarto render --to html`
-    path: source-folder # By default, the current working dir is used i.e `quarto render .` Can also be a path to a single .qmd file.
+    path: source-folder # By default, the current working dir is used i.e `quarto render .`
 ```
+
+`path:` can be a path to a subdirectory containing the quarto project to be rendered or a path to a single .qmd file


### PR DESCRIPTION
Just clarifies that the `path:` setting can point to a single .qmd document.