### PR TITLE
chore: update checkout to v4

### DIFF
--- a/examples/example-08-publish-to-others-services.md
+++ b/examples/example-08-publish-to-others-services.md
@@ -25,7 +25,7 @@ jobs:
       deployments: write # needed for Cloudflare
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/examples/quarto-publish-example.yml
+++ b/examples/quarto-publish-example.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Check out repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2


### PR DESCRIPTION
This PR updates checkout workflow to v4.
See <https://github.com/actions/checkout/releases/tag/v4.0.0>.