### PR TITLE
fix: use explicit default for version

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -3,8 +3,9 @@ author: 'Christophe Dervieux'
 description: 'This action will setup Quarto from the git repository https://github.com/quarto-dev/quarto-cli/'
 inputs:
   version:
-    description: 'The version of Quarto to use. Either a release tag (eg. 0.9.486) or "pre-release" for latest built dev version. If missing, uses latest stable version.'
+    description: 'The version of Quarto to use. Either a release tag without "v" prefix (e.g., "0.9.486"), "pre-release" for latest built dev version, or 'release', for the latest stable version.'
     required: false
+    default: 'release'
   tinytex:
     description: 'If true, install TinyTex, required for PDF rendering'
     required: false
@@ -41,7 +42,7 @@ runs:
       run: |
         if [ ${{ runner.os }} != "Windows" ]; then
           # On Windows scoop will be used so no need to download the release
-          if [ -z "${{inputs.version}}" ]; then
+          if [ "${{inputs.version}}" == "release"]; then
             # download the latest stable release
             gh release download --repo github.com/quarto-dev/quarto-cli --pattern ${{ format('*{0}', env.BUNDLE_EXT) }}
             version=$(curl https://quarto.org/docs/download/_download.json | jq -r '.version')


### PR DESCRIPTION
This PR set the default value for version to allow switching between release/pre-release without having to remove the version specification which is unintuitive.

(Note that "latest" pointing to "pre-release" feels really off)