### PR TITLE
Use array format for branch name

### DIFF
--- a/examples/quarto-publish-example.yml
+++ b/examples/quarto-publish-example.yml
@@ -1,6 +1,7 @@
 on:
   push:
-    branches: main
+    branches:
+      - main
 
 name: Render and Publish
 


### PR DESCRIPTION
My editor detects the current syntax as incorrect. It seems like GitHub's docs also use the array format for single branch names, e.g. https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#using-activity-types-and-filters-with-multiple-events