### PR TITLE
Adding render option to the actions "render" and "publish" and cleaning code

### DIFF
--- a/publish/action.yml
+++ b/publish/action.yml
@@ -36,6 +36,10 @@ inputs:
     description: 'If not true, do not render project before publishing'
     required: false
     default: "true"
+  profile:
+    description: 'Profiles to use when rendering the quarto project'
+    required: false
+    default: ""    
 runs:
   using: 'composite'
   steps: 
@@ -50,12 +54,20 @@ runs:
       run: |
         git config --global user.email "${{ inputs.GITHUB_EMAIL }}"
         git config --global user.name "${{ inputs.GITHUB_USERNAME }}"
+        
         TARGET="${{ inputs.to }}"
-        if [ "$TARGET" == "" ]; then
+        if [ -z "$TARGET" ]; then
           TARGET="${{ inputs.target }}"
         fi
+        
+        publish_command="quarto publish $TARGET ${{ inputs.path }} --no-browser"
+        
         if [ "${{ inputs.render }}" != "true" ]; then
-          quarto publish $TARGET ${{ inputs.path }} --no-render --no-browser
-        else
-          quarto publish $TARGET ${{ inputs.path }} --no-browser
+          publish_command="$publish_command --no-render"
         fi
+
+        if [ ! -z "${{ inputs.profile }}" ]; then
+          publish_command="$publish_command --profile ${{ inputs.profile }}"
+        fi
+        
+        eval $publish_command

--- a/render/action.yml
+++ b/render/action.yml
@@ -9,6 +9,9 @@ inputs:
     description: 'Subdirectory containing the quarto project to be rendered'
     required: false
     default: "."
+  profile:
+    description: 'Profiles to use when rendering the quarto project'
+    required: false
 runs:
   using: 'composite'
   steps: 
@@ -26,11 +29,14 @@ runs:
       env:
         QUARTO_PRINT_STACK: true
       run: |
-        if [ "${{ inputs.to }}" == "" ]; then
-          quarto render ${{ inputs.path }}
-        else
-          quarto render ${{ inputs.path }} --to ${{ inputs.to }}
+        render_command="quarto render ${{ inputs.path }}"
+        if [ ! -z "${{ inputs.to }}" ]; then
+          render_command="$render_command --to ${{ inputs.to }}"
         fi
+        if [ ! -z "${{ inputs.profile }}" ]; then
+          render_command="$render_command --profile ${{ inputs.profile }}"
+        fi
+        eval $render_command
         if [ -f "_book" ]; then
           echo "QUARTO_OUTPUT=_book" >> $GITHUB_ENV
         elif [ -f "_site" ]; then


### PR DESCRIPTION
This pull request addresses the feature in https://github.com/quarto-dev/quarto-actions/issues/102

What I did:

- Introduced an optional profile input argument for specifying the profile to give to the render command.

- To simplify the conditional logic the command strings are now dynamically build. 

- Moved the Git configuration to a separate step for clarity.