### PR TITLE
Remove chrome checking 

### DIFF
--- a/render/action.yml
+++ b/render/action.yml
@@ -12,6 +12,11 @@ inputs:
 runs:
   using: 'composite'
   steps: 
+    # Chrome v128 started to create problem. Pin previous version in the meantime
+    - name: Install Chrome
+      uses: browser-actions/setup-chrome@v1
+      with:
+        chrome-version: 127
     # The Check Chromium step appears necessary to avoid a crash/hang when rendering PDFs
     # https://github.com/quarto-dev/quarto-actions/issues/45#issuecomment-1562599451
     #

--- a/render/action.yml
+++ b/render/action.yml
@@ -13,20 +13,20 @@ runs:
   using: 'composite'
   steps: 
     # Chrome v128 started to create problem. Pin previous version in the meantime
-    - name: Install Chrome
-      uses: browser-actions/setup-chrome@v1
-      with:
-        chrome-version: 127
+    # - name: Install Chrome
+    # uses: browser-actions/setup-chrome@v1
+    #  with:
+    #    chrome-version: 127
     # The Check Chromium step appears necessary to avoid a crash/hang when rendering PDFs
     # https://github.com/quarto-dev/quarto-actions/issues/45#issuecomment-1562599451
     #
     # chromium is installed in the ubuntu 21 runners in GHA, so no need to install it
-    - name: 'Check Chromium'
-      if: ${{ runner.os == 'Linux' }}
-      run: |
-        echo $(which google-chrome)
-        $(which google-chrome) --headless --no-sandbox --disable-gpu --renderer-process-limit=1 https://www.chromestatus.com
-      shell: bash
+    #- name: 'Check Chromium'
+    #  if: ${{ runner.os == 'Linux' }}
+    #  run: |
+    #    echo $(which google-chrome)
+    #    $(which google-chrome) --headless --no-sandbox --disable-gpu --renderer-process-limit=1 https://www.chromestatus.com
+    #  shell: bash
     - name: 'Render'
       env:
         QUARTO_PRINT_STACK: true

--- a/render/action.yml
+++ b/render/action.yml
@@ -24,8 +24,8 @@ runs:
     - name: 'Check Chromium'
       if: ${{ runner.os == 'Linux' }}
       run: |
-        echo $(which chromium-browser)
-        $(which chromium-browser) --headless --no-sandbox --disable-gpu --renderer-process-limit=1 https://www.chromestatus.com
+        echo $(which google-chrome)
+        $(which google-chrome) --headless --no-sandbox --disable-gpu --renderer-process-limit=1 https://www.chromestatus.com
       shell: bash
     - name: 'Render'
       env:


### PR DESCRIPTION
This creates some problems with new chrome; It seems on CI this is creating hanging workflow with the new way chrome is behaving.

Something has changed and even going back to chrome 127 does not fixes it. 

So for now we remove what was added for https://github.com/quarto-dev/quarto-actions/issues/45 

This found in our CI and reported too by our users
- https://github.com/quarto-dev/quarto-actions/issues/115