### PR TITLE
fix: avoid hanging terminal if older version is available

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -100,7 +100,7 @@ runs:
         QUARTO_PRINT_STACK: true
       if: ${{ inputs.tinytex == 'true'}}
       run: |
-        quarto install tool tinytex --log-level warning
+        quarto install tool tinytex --no-prompt --log-level warning
         case $RUNNER_OS in 
           "Linux")
               echo "$HOME/bin" >> $GITHUB_PATH


### PR DESCRIPTION
Hi all! This is an issue we've encountered recently...

Quarto was already installed in a self-hosted runner (for various, undetermined reasons). We weren't aware of this and we were also using the quarto-action for setting up quarto. Anyway, it seems like we already had tinytex installed in our machine as well via quarto, but we had an old version... and quarto was prompting us for an update.

This is not possible on CI/CD and thus I would assume that some other users might be impacted by this. For CI/CD purposes, I think it's best if we just assume ``--no-prompt`` to be the standard =)

Leaving the PR for the maintainers to review! Happy to provide more feedback if needed 