### PR TITLE
Update action.yml

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -72,7 +72,7 @@ runs:
         [ ${{ runner.os }} != "Windows" ] && installer=${{ steps.download-quarto.outputs.installer }}
         case $RUNNER_OS in 
           "Linux")
-              sudo apt install ./$installer
+              sudo apt -y install ./$installer
               ;;
            "macOS")
               sudo installer -pkg ./$installer -target '/'


### PR DESCRIPTION
This PR fixes a tiny issue since `apt` can occasionally ask for interactive input. The specific instance I had was that there was a question about whether installation should continue. We want noninteractive behaviour in a workflow and apt I believe does not respect `DEBIAN_FRONTEND=noninteractive` environment variable.