### PR TITLE
Do not rely on gh cli utility

### DIFF
--- a/setup/action.yml
+++ b/setup/action.yml
@@ -52,8 +52,8 @@ runs:
           # On Windows scoop will be used so no need to download the release
           if [ "${{inputs.version}}" == "release" ]; then
             # download the latest stable release
-            gh release download --repo github.com/quarto-dev/quarto-cli --pattern ${{ format('*{0}', env.BUNDLE_EXT) }}
             version=$(curl https://quarto.org/docs/download/_download.json | jq -r '.version')
+            wget https://github.com/quarto-dev/quarto-cli/releases/download/v$version/quarto-$version-${{env.BUNDLE_EXT}}
             echo "version=${version}" >> $GITHUB_OUTPUT
           elif [ "${{inputs.version}}" == "LATEST" -o "${{inputs.version}}" == "pre-release" ]; then
             # get latest pre release version 


### PR DESCRIPTION
`gh` is great and is installed by default in GH default runners, but it is not guaranteed to always be available, especially when using a default docker container.

Currently

```yaml
   - uses: quarto-dev/quarto-actions/setup@main
     with:
       version: "release"
```

will fail on custom docker containers without `gh`.

This PR removes this dependency.

There is still a dependency on `jq` but it is more difficult to remove and used in more cases.