### PR TITLE
Fix Windows installation error handling

### DIFF
--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ inputs.version && fromJSON(format('["{0}"]', inputs.version)) || fromJSON('["release", "pre-release"]') }}
+        version: ${{ inputs.version && fromJSON(format('["{0}"]', inputs.version)) || fromJSON('["release", "pre-release", "1.8.25"]') }}
         config:
           # Default config for standard platforms
           - os: macos-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ inputs.version && fromJSON(format('["{0}"]', inputs.version)) || fromJSON('["release", "pre-release", "1.8.25"]') }}
+        version: ${{ inputs.version && fromJSON(format('["{0}"]', inputs.version)) || fromJSON('["release", "pre-release", "1.8.25", "0.0.1"]') }}
         config:
           # Default config for standard platforms
           - os: macos-latest

--- a/.github/workflows/test.yaml
+++ b/.github/workflows/test.yaml
@@ -29,7 +29,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        version: ${{ inputs.version && fromJSON(format('["{0}"]', inputs.version)) || fromJSON('["release", "pre-release", "1.8.25", "0.0.1"]') }}
+        version: ${{ inputs.version && fromJSON(format('["{0}"]', inputs.version)) || fromJSON('["release", "pre-release", "1.8.25"]') }}
         config:
           # Default config for standard platforms
           - os: macos-latest

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -98,7 +98,9 @@ runs:
               exit 1
               ;;
         esac
-        [ ${{ runner.os }} != "Windows" ] && rm $installer
+        if [ "${{ runner.os }}" != "Windows" ]; then
+          rm $installer
+        fi
       shell: bash
       working-directory: ${{ runner.temp }}
     - name: 'Verify Quarto installation'

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -92,6 +92,20 @@ runs:
               else
                 powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1 ${{ inputs.version }}
               fi
+
+              # Check if installation succeeded
+              if [ $? -ne 0 ]; then
+                  echo "ERROR: Quarto installation failed"
+                  exit 1
+              fi
+
+              # Verify Quarto is available
+              if ! command -v quarto &> /dev/null; then
+                  echo "ERROR: Quarto installation completed but quarto command not found"
+                  exit 1
+              fi
+
+              echo "Quarto Installed !"
               ;;
             *)
               echo "$RUNNER_OS not supported"
@@ -99,7 +113,7 @@ runs:
               ;;
         esac
         [ ${{ runner.os }} != "Windows" ] && rm $installer
-        echo "Quarto Installed !"
+        [ ${{ runner.os }} != "Windows" ] && echo "Quarto Installed !"
       shell: bash
       working-directory: ${{ runner.temp }}
     - name: 'Install TinyTeX'

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -99,12 +99,6 @@ runs:
                   exit 1
               fi
 
-              # Verify Quarto is available
-              if ! command -v quarto &> /dev/null; then
-                  echo "ERROR: Quarto installation completed but quarto command not found"
-                  exit 1
-              fi
-
               echo "Quarto Installed !"
               ;;
             *)

--- a/setup/action.yml
+++ b/setup/action.yml
@@ -77,7 +77,7 @@ runs:
       run: |
         # Install quarto
         [ ${{ runner.os }} != "Windows" ] && installer=${{ steps.download-quarto.outputs.installer }}
-        case $RUNNER_OS in 
+        case $RUNNER_OS in
           "Linux")
               sudo apt -y install ./$installer
               ;;
@@ -92,14 +92,6 @@ runs:
               else
                 powershell -File $GITHUB_ACTION_PATH/install-quarto-windows.ps1 ${{ inputs.version }}
               fi
-
-              # Check if installation succeeded
-              if [ $? -ne 0 ]; then
-                  echo "ERROR: Quarto installation failed"
-                  exit 1
-              fi
-
-              echo "Quarto Installed !"
               ;;
             *)
               echo "$RUNNER_OS not supported"
@@ -107,9 +99,17 @@ runs:
               ;;
         esac
         [ ${{ runner.os }} != "Windows" ] && rm $installer
-        [ ${{ runner.os }} != "Windows" ] && echo "Quarto Installed !"
       shell: bash
       working-directory: ${{ runner.temp }}
+    - name: 'Verify Quarto installation'
+      run: |
+        if ! command -v quarto &> /dev/null; then
+            echo "ERROR: Quarto installation completed but quarto command not found"
+            exit 1
+        fi
+        echo "Quarto Installed !"
+        quarto --version
+      shell: bash
     - name: 'Install TinyTeX'
       env:
         QUARTO_PRINT_STACK: true

--- a/setup/install-quarto-windows.ps1
+++ b/setup/install-quarto-windows.ps1
@@ -14,16 +14,54 @@
     ttps:/go.microsoft.com/fwlink/?LinkID=135170
 #>
 
-Invoke-WebRequest -useb get.scoop.sh -outfile 'install.ps1'
-.\install.ps1 -RunAsAdmin
-Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+# Exit immediately on errors
+$ErrorActionPreference = "Stop"
+
+try {
+    Invoke-WebRequest -useb get.scoop.sh -outfile 'install.ps1'
+    .\install.ps1 -RunAsAdmin
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Scoop installation failed with exit code $LASTEXITCODE"
+        exit 1
+    }
+    Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+} catch {
+    Write-Error "Failed to download or install Scoop: $_"
+    exit 1
+}
 
 $version=$args[0]
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
+if ($LASTEXITCODE -ne 0) {
+    Write-Error "Failed to add r-bucket with exit code $LASTEXITCODE"
+    exit 1
+}
+
 if ([string]::IsNullOrEmpty($version)) {
     scoop install quarto
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install quarto with exit code $LASTEXITCODE"
+        exit 1
+    }
 } elseif ($version -eq 'pre-release') {
     Invoke-Expression -Command "scoop install quarto-prerelease"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install quarto-prerelease with exit code $LASTEXITCODE"
+        exit 1
+    }
 } else {
     Invoke-Expression -Command "scoop install quarto@$version"
+    if ($LASTEXITCODE -ne 0) {
+        Write-Error "Failed to install quarto version $version with exit code $LASTEXITCODE"
+        exit 1
+    }
 }
+
+# Verify Quarto is available
+$quartoPath = Get-Command quarto -ErrorAction SilentlyContinue
+if (-not $quartoPath) {
+    Write-Error "Quarto installation completed but quarto command not found in PATH"
+    exit 1
+}
+
+exit 0

--- a/setup/install-quarto-windows.ps1
+++ b/setup/install-quarto-windows.ps1
@@ -24,7 +24,9 @@ try {
         Write-Error "Scoop installation failed with exit code $LASTEXITCODE"
         exit 1
     }
-    Join-Path (Resolve-Path ~).Path "scoop\shims" >> $Env:GITHUB_PATH
+    $scoopShims = Join-Path (Resolve-Path ~).Path "scoop\shims"
+    $scoopShims >> $Env:GITHUB_PATH
+    $env:PATH = "$scoopShims;$env:PATH"
 } catch {
     Write-Error "Failed to download or install Scoop: $_"
     exit 1

--- a/setup/install-quarto-windows.ps1
+++ b/setup/install-quarto-windows.ps1
@@ -34,29 +34,11 @@ try {
 
 $version=$args[0]
 scoop bucket add r-bucket https://github.com/cderv/r-bucket.git
-if ($LASTEXITCODE -ne 0) {
-    Write-Error "Failed to add r-bucket with exit code $LASTEXITCODE"
-    exit 1
-}
 
 if ([string]::IsNullOrEmpty($version)) {
     scoop install quarto
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to install quarto with exit code $LASTEXITCODE"
-        exit 1
-    }
 } elseif ($version -eq 'pre-release') {
-    Invoke-Expression -Command "scoop install quarto-prerelease"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to install quarto-prerelease with exit code $LASTEXITCODE"
-        exit 1
-    }
+    scoop install quarto-prerelease
 } else {
-    Invoke-Expression -Command "scoop install quarto@$version"
-    if ($LASTEXITCODE -ne 0) {
-        Write-Error "Failed to install quarto version $version with exit code $LASTEXITCODE"
-        exit 1
-    }
+    scoop install quarto@$version
 }
-
-exit 0

--- a/setup/install-quarto-windows.ps1
+++ b/setup/install-quarto-windows.ps1
@@ -25,8 +25,7 @@ try {
         exit 1
     }
     $scoopShims = Join-Path (Resolve-Path ~).Path "scoop\shims"
-    $scoopShims >> $Env:GITHUB_PATH
-    $env:PATH = "$scoopShims;$env:PATH"
+    Add-Content -Path $Env:GITHUB_PATH -Value $scoopShims
 } catch {
     Write-Error "Failed to download or install Scoop: $_"
     exit 1

--- a/setup/install-quarto-windows.ps1
+++ b/setup/install-quarto-windows.ps1
@@ -59,11 +59,4 @@ if ([string]::IsNullOrEmpty($version)) {
     }
 }
 
-# Verify Quarto is available
-$quartoPath = Get-Command quarto -ErrorAction SilentlyContinue
-if (-not $quartoPath) {
-    Write-Error "Quarto installation completed but quarto command not found in PATH"
-    exit 1
-}
-
 exit 0


### PR DESCRIPTION
When Scoop fails to download or install Quarto (e.g., 503 server errors), the action would still report "Quarto Installed !" and succeed.

The PowerShell script had no error handling and the bash wrapper didn't check exit codes, causing installation failures to be silently ignored.

This PR fixes that