### PR TITLE
Bump a few GHA workflow versions

### DIFF
--- a/examples/README.md
+++ b/examples/README.md
@@ -25,7 +25,7 @@
 
   ```yaml
         - name: Check out repository
-          uses: actions/checkout@v4
+          uses: actions/checkout@v6
           with:
             lfs: true # needed when using lfs for image storage
   ```

--- a/examples/example-07-publish-single-format.md
+++ b/examples/example-07-publish-single-format.md
@@ -12,7 +12,7 @@ With the `publish` action, it is either rendering all format by default, or none
     to: html
 
 - name: Publish HTML book
-    uses: quarto-dev/quarto-actions/publish@v2
+  uses: quarto-dev/quarto-actions/publish@v2
   with:
     target: gh-pages
     render: false

--- a/examples/example-08-publish-to-others-services.md
+++ b/examples/example-08-publish-to-others-services.md
@@ -25,7 +25,7 @@ jobs:
       deployments: write # needed for Cloudflare
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
 
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2

--- a/examples/quarto-publish-example-with-uv.yml
+++ b/examples/quarto-publish-example-with-uv.yml
@@ -12,7 +12,7 @@ jobs:
       contents: write
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
       - name: Install uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/examples/quarto-publish-example-with-uv.yml
+++ b/examples/quarto-publish-example-with-uv.yml
@@ -14,7 +14,7 @@ jobs:
       - name: Check out repository
         uses: actions/checkout@v6
       - name: Install uv
-        uses: astral-sh/setup-uv@v6
+        uses: astral-sh/setup-uv@v8.2.0
         with:
           enable-cache: true
       - name: Install the project

--- a/examples/quarto-publish-example.yml
+++ b/examples/quarto-publish-example.yml
@@ -16,7 +16,7 @@ jobs:
     
     steps:
       - name: Check out repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v6
         
       - name: Set up Quarto
         uses: quarto-dev/quarto-actions/setup@v2
@@ -76,4 +76,3 @@ jobs:
       #     CONFLUENCE_USER_EMAIL: ${{ secrets.CONFLUENCE_USER_EMAIL }}
       #     CONFLUENCE_AUTH_TOKEN: ${{ secrets.CONFLUENCE_AUTH_TOKEN }}
       #     CONFLUENCE_DOMAIN: ${{ secrets.CONFLUENCE_DOMAIN }}
-      


### PR DESCRIPTION
I used these the other day and noticed a few things are out of date.

* Bump actions/checkout to v6
* Bump setup-uv to v8.2.0 - note they no longer release sliding tags
* An indentation fix.

What I didn't fix 

- In examples/example-08-publish-to-others-services.md the `cloudflare/pages-action` action is deprecated - they now recommend using their [`cloudflare/wrangler-action`](https://github.com/cloudflare/wrangler-action).